### PR TITLE
Added logic to handle relative path URLs in <link> elements

### DIFF
--- a/projects/popout-window/src/lib/popout-window.component.ts
+++ b/projects/popout-window/src/lib/popout-window.component.ts
@@ -92,7 +92,13 @@ export class PopoutWindowComponent implements AfterViewInit {
       }
 
       document.querySelectorAll('link, style').forEach(htmlElement => {
-        this.externalWindow.document.head.appendChild(htmlElement.cloneNode(true));
+        const elClone = (htmlElement.cloneNode(true) as HTMLElement);
+        if (elClone.tagName.toLowerCase() === 'link'
+          && elClone.getAttribute('href')
+          && elClone.getAttribute('href').indexOf('http') !== 0) {
+          elClone.setAttribute('href', document.location.origin + document.location.pathname + elClone.getAttribute('href'));
+        }
+        this.externalWindow.document.head.appendChild(elClone);
       });
 
       const host = new DomPortalOutlet(

--- a/src/assets/test.css
+++ b/src/assets/test.css
@@ -1,0 +1,3 @@
+.div1 {
+    font-size: 30px;s
+}

--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,7 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="stylesheet" href="/assets/test.css">
 </head>
 <body>
   <app-main></app-main>


### PR DESCRIPTION
In working with this module, I noticed some issues with CSS stylesheets not being applied properly in the child windows. I isolated the issue to ones with relative paths, which will not work, because the child window has no URL of its own. So I added some logic to prepend the host and path of the main window to any relative URLs.
Thx.