### PR TITLE
Persistent stylebinding

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,11 +5,13 @@ import {FormsModule} from '@angular/forms';
 import { NgStartComponent } from './ng-start/ng-start.component';
 import {PopoutWindowModule} from '../../projects/popout-window/src/lib/popout-window.module';
 import {DragDropModule} from '@angular/cdk/drag-drop';
+import { ExampleChildComponent } from './example-child/example-child.component';
 
 @NgModule({
   declarations: [
     MainComponent,
-    NgStartComponent
+    NgStartComponent,
+    ExampleChildComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/example-child/example-child.component.css
+++ b/src/app/example-child/example-child.component.css
@@ -1,0 +1,5 @@
+div.childDiv {
+  background-color: red;
+  width: 300px;
+  height: 100px;
+}

--- a/src/app/example-child/example-child.component.html
+++ b/src/app/example-child/example-child.component.html
@@ -1,0 +1,1 @@
+<div class="childDiv">Style (red background) will not load if component first shown when popped out, without changes</div>

--- a/src/app/example-child/example-child.component.spec.ts
+++ b/src/app/example-child/example-child.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ExampleChildComponent } from './example-child.component';
+
+describe('ExampleChildComponent', () => {
+  let component: ExampleChildComponent;
+  let fixture: ComponentFixture<ExampleChildComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ExampleChildComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ExampleChildComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/example-child/example-child.component.ts
+++ b/src/app/example-child/example-child.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-example-child',
+  templateUrl: './example-child.component.html',
+  styleUrls: ['./example-child.component.css']
+})
+export class ExampleChildComponent {}

--- a/src/app/main/main.component.html
+++ b/src/app/main/main.component.html
@@ -58,6 +58,13 @@
         binding jahBless:
         <input [(ngModel)]="jahBless" />
       </label>
+      <br>
+      <label>
+        show hidden child component
+        <input type="checkbox" [(ngModel)]="childShown"/>
+      </label>
+      <app-example-child *ngIf="childShown"></app-example-child>
+      <br />
       <br />
       <button (click)="windowComponent.popOut()" style="margin-right: 10px">pop me Out</button>
       <button (click)="windowComponent.popIn()">take me inside</button>

--- a/src/app/main/main.component.ts
+++ b/src/app/main/main.component.ts
@@ -10,6 +10,7 @@ export class MainComponent implements OnInit {
 
   jahBless = 'Jah Bless';
   isChecked: any;
+  childShown = false;
   private rect;
 
   @ViewChild('resizableDiv') resizableDiv: ElementRef;


### PR DESCRIPTION
This PR should help show an issue that I faced using this code in production, as well as a fix I wrote for the issue.

The problem: After the child component is popped out, any further style-changes to the parent window are not applied to the child window. This became an issue because Angular loads component styling into <style></style> tags only once they are shown, and when it does - they are only loaded to the parent window. So if a child doesn't exist on the DOM (e.g. due to *ngIf) before it's popped out, once it is shown, the styles will not propagate to the child window.

The first commit is the fix, the second commit adds example code which should illustrate the issue, which may need to be removed.

The fix is accomplished by observing style mutations to the <head> tag, and copying them over to the child window.

*I also added a 'closed' emitter; I feel this can be useful in a few ways - including in my case, where I had to run change detection on close, which wasn't triggered by closing the child window.