### PR TITLE
Observer undefined on parent component ngDestroy

### DIFF
--- a/projects/popout-window/src/lib/popout-window.component.ts
+++ b/projects/popout-window/src/lib/popout-window.component.ts
@@ -47,7 +47,7 @@ export class PopoutWindowComponent implements OnDestroy  {
   ) {}
 
   ngOnDestroy(): void {
-    this.observer.disconnect();
+    this.observer?.disconnect();
     this.close();
   }
 


### PR DESCRIPTION
observer(MutationObserver) is undefined for parent component when working with (ng v13). I added a null operator on popout-window.component ngOnDestroy